### PR TITLE
fix(middleware/logger): format duration to 5 decimal points

### DIFF
--- a/echo/middleware/logger/logger.go
+++ b/echo/middleware/logger/logger.go
@@ -1,6 +1,7 @@
 package logger
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/google/uuid"
@@ -61,7 +62,7 @@ func Middleware() func(echo.HandlerFunc) echo.HandlerFunc {
 
 			log.Root(logger.Data{
 				"status_code": c.Response().Status,
-				"duration":    t2.Sub(t1).Seconds() * 1000,
+				"duration":    fmt.Sprintf("%.5f", t2.Sub(t1).Seconds()*1000),
 				"referer":     c.Request().Referer(),
 				"user_agent":  c.Request().UserAgent(),
 			}).Info("request handled")

--- a/echo/v4/middleware/logger/logger.go
+++ b/echo/v4/middleware/logger/logger.go
@@ -1,6 +1,7 @@
 package logger
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/google/uuid"
@@ -61,7 +62,7 @@ func Middleware() func(echo.HandlerFunc) echo.HandlerFunc {
 
 			log.Root(logger.Data{
 				"status_code": c.Response().Status,
-				"duration":    t2.Sub(t1).Seconds() * 1000,
+				"duration":    fmt.Sprintf("%.5f", t2.Sub(t1).Seconds()*1000),
 				"referer":     c.Request().Referer(),
 				"user_agent":  c.Request().UserAgent(),
 			}).Info("request handled")


### PR DESCRIPTION
### what

there are times when the duration has some floating point math issues and end up looking bad e.g. `INF request handled duration=11.094790999999999`. this just formats the duration to a max of 5 decimal points