### PR TITLE
fix(middleware/logger): reload logger and use x-log-level

### DIFF
--- a/echo/middleware/logger/logger.go
+++ b/echo/middleware/logger/logger.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	levelHeader   = "log-level"
+	levelHeader   = "x-log-level"
 	versionHeader = "x-version"
 	echoIDKey     = "id"
 )
@@ -59,6 +59,10 @@ func Middleware() func(echo.HandlerFunc) echo.HandlerFunc {
 				c.Error(err)
 			}
 			t2 := time.Now()
+
+			// We reload the logger before we emit the log line so that we pick up any changes/additional
+			// fields that might've been added in a downstream middleware.
+			log = logger.FromContext(c.Request().Context())
 
 			log.Root(logger.Data{
 				"status_code": c.Response().Status,

--- a/echo/v4/middleware/logger/logger.go
+++ b/echo/v4/middleware/logger/logger.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	levelHeader   = "log-level"
+	levelHeader   = "x-log-level"
 	versionHeader = "x-version"
 	echoIDKey     = "id"
 )
@@ -59,6 +59,10 @@ func Middleware() func(echo.HandlerFunc) echo.HandlerFunc {
 				c.Error(err)
 			}
 			t2 := time.Now()
+
+			// We reload the logger before we emit the log line so that we pick up any changes/additional
+			// fields that might've been added in a downstream middleware.
+			log = logger.FromContext(c.Request().Context())
 
 			log.Root(logger.Data{
 				"status_code": c.Response().Status,


### PR DESCRIPTION
### what

- change the log level header from `log-level` to `x-log-level` since it's not a standard header
- reload the logger before emitting the log line so we can pick up any downstream changes