### PR TITLE
fix(logger): instead of 'pretty', use 'console'

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -41,7 +41,7 @@ func init() {
 	switch os.Getenv("LOG_FORMAT") {
 	case "json":
 		output = os.Stdout
-	case "pretty", "":
+	case "console", "":
 		output = writer.ConsoleWriter{Out: os.Stderr}
 	}
 }


### PR DESCRIPTION
### what

it seems like `console` is more standard than `pretty`, so i'll use that